### PR TITLE
Fix code scanning alert #193: Creating an ASP.NET debug binary may reveal sensitive information

### DIFF
--- a/csharp/ql/test/query-tests/Security Features/CWE-011/bad1/Web.config
+++ b/csharp/ql/test/query-tests/Security Features/CWE-011/bad1/Web.config
@@ -3,7 +3,6 @@
   <system.web>
     <compilation
       defaultLanguage="c#"
-      debug="true"
     />
   </system.web>
 </configuration>


### PR DESCRIPTION
Fixes [https://github.com/aka2024/codeql/security/code-scanning/193](https://github.com/aka2024/codeql/security/code-scanning/193)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
