### PR TITLE
Fix code scanning alert #197: Page request validation is disabled

### DIFF
--- a/csharp/ql/test/query-tests/Security Features/CWE-016/ASPNetPagesValidateRequest/ASPNetPagesValidateRequestBad.config
+++ b/csharp/ql/test/query-tests/Security Features/CWE-016/ASPNetPagesValidateRequest/ASPNetPagesValidateRequestBad.config
@@ -1,5 +1,5 @@
 <configuration>
   <system.web>
-    <pages validateRequest="false" />
+    <pages validateRequest="true" />
   </system.web>
 </configuration>


### PR DESCRIPTION
Fixes [https://github.com/aka2024/codeql/security/code-scanning/197](https://github.com/aka2024/codeql/security/code-scanning/197)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
