### PR TITLE
Fix code scanning alert #196: Page request validation is disabled

### DIFF
--- a/csharp/ql/src/Security Features/CWE-016/ASPNetPagesValidateRequestBad.config
+++ b/csharp/ql/src/Security Features/CWE-016/ASPNetPagesValidateRequestBad.config
@@ -1,5 +1,5 @@
 <configuration>
   <system.web>
-    <pages validateRequest="false" />
+    <pages validateRequest="true" />
   </system.web>
 </configuration>


### PR DESCRIPTION
Fixes [https://github.com/aka2024/codeql/security/code-scanning/196](https://github.com/aka2024/codeql/security/code-scanning/196)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
