### PR TITLE
Fix code scanning alert #199: Missing global error handler

### DIFF
--- a/csharp/ql/test/query-tests/Security Features/CWE-248/MissingASPNETGlobalErrorHandler/WebConfigOff/Web.config
+++ b/csharp/ql/test/query-tests/Security Features/CWE-248/MissingASPNETGlobalErrorHandler/WebConfigOff/Web.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <system.web>
-    <customErrors mode="Off">
+    <customErrors mode="RemoteOnly">
     </customErrors>
   </system.web>
 </configuration>


### PR DESCRIPTION
Fixes [https://github.com/aka2024/codeql/security/code-scanning/199](https://github.com/aka2024/codeql/security/code-scanning/199)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
