### PR TITLE
Fix code scanning alert no. 198: Missing global error handler

### DIFF
--- a/csharp/ql/src/Security Features/CWE-248/BadWeb.config
+++ b/csharp/ql/src/Security Features/CWE-248/BadWeb.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
   <system.web>
-    <customErrors mode="Off">
+    <customErrors mode="RemoteOnly">
       ...
     </customErrors>
   </system.web>


### PR DESCRIPTION
Fixes [https://github.com/aka2024/codeql/security/code-scanning/198](https://github.com/aka2024/codeql/security/code-scanning/198)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
